### PR TITLE
Fixed import in example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ package main
 import (
   "time"
 
-  "github.com/GlobalFreightSolutions/logrus-datadog-hook/datadog"
+  datadog "github.com/GlobalFreightSolutions/logrus-datadog-hook"
   "github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
The example usage in the readme has an incorrect import.

This fixes that. 