### PR TITLE
send done message on go routine so as not to block the method

### DIFF
--- a/datadog.go
+++ b/datadog.go
@@ -143,7 +143,7 @@ func New(options *Options) (*DatadogHook, error) {
 func (h *DatadogHook) Close() {
 	close(h.entryC)
 	h.ticker.Stop()
-	h.done <- true
+	go func() { h.done <- true }()
 	h.wg.Wait()
 	close(h.done)
 }


### PR DESCRIPTION
This closes #6 

There may well be a better way to do this, perhaps with a buffered channel maybe, but this is pretty neat and simple.

And if you're gonna use go you might as well use goroutines.